### PR TITLE
Increase SO_DEP_MAX_TRANSCEIVE to allow larger messages

### DIFF
--- a/system/etc/libnfc-nci.conf
+++ b/system/etc/libnfc-nci.conf
@@ -391,3 +391,7 @@ NFA_PROPRIETARY_CFG={05:FF:FF:06:81:80:70:FF:FF}
 #  If set to 1, NFCC is using bail out mode for either Type A or Type B poll.
 NFA_POLL_BAIL_OUT_MODE=0x01
 #################################################################################
+
+#################################################################################
+# Enable extended APDU length for ISO_DEP
+ISO_DEP_MAX_TRANSCEIVE=0xFEFF


### PR DESCRIPTION
Set `ISO_DEP_MAX_TRANSCEIVE=0xFEFF` to fix NFC max transceive length issues (see https://gitlab.com/LineageOS/issues/android/-/issues/576).

When using e.g. a YubiKey NFC with a 4096 bit PGP key, the error "Transceive length exceeds supported maximum" is thrown by OpenKeychain. This PR fixes the issue.

On the stock OS it was not a problem, so it makes sense to fix it in this module right away.